### PR TITLE
Cherry-pick pr limit

### DIFF
--- a/.buildkite/scripts/cherry-pick-from-milestone.sh
+++ b/.buildkite/scripts/cherry-pick-from-milestone.sh
@@ -137,6 +137,7 @@ PR_DATA=$(mktemp)
 trap "rm -f $PR_DATA" EXIT
 
 if ! gh pr list --state merged --search "milestone:${MILESTONE}" \
+    --limit 1000 \
     --json number,title,mergeCommit,mergedAt \
     --jq 'sort_by(.mergedAt) | .[] | "\(.mergeCommit.oid)\t\(.number)\t\(.title)"' > "$PR_DATA" 2>/dev/null; then
     log_error "Failed to fetch PRs from milestone '${MILESTONE}'"


### PR DESCRIPTION
## Purpose

Fixes an issue where `gh pr list` in `.buildkite/scripts/cherry-pick-from-milestone.sh` would silently truncate results to 30 PRs by default. This could lead to incomplete cherry-picks for milestones with more than 30 merged PRs. The fix adds `--limit 1000` to ensure all PRs are retrieved.

## Test Plan

Manually inspect `.buildkite/scripts/cherry-pick-from-milestone.sh` to confirm the `--limit 1000` flag has been added to the `gh pr list` command.

## Test Result

The `gh pr list` command in `.buildkite/scripts/cherry-pick-from-milestone.sh` now includes `--limit 1000`.

```diff
--- a/.buildkite/scripts/cherry-pick-from-milestone.sh
+++ b/.buildkite/scripts/cherry-pick-from-milestone.sh
@@ -137,6 +137,7 @@ PR_DATA=$(mktemp)
 trap "rm -f $PR_DATA" EXIT
 
 if ! gh pr list --state merged --search "milestone:${MILESTONE}" \
+    --limit 1000 \
     --json number,title,mergeCommit,mergedAt \
     --jq 'sort_by(.mergedAt) | .[] | "\(.mergeCommit.oid)\t\(.number)\t\(.title)"' > "$PR_DATA" 2>/dev/null; then
     log_error "Failed to fetch PRs from milestone '${MILESTONE}'"
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Ensures the milestone cherry-pick script processes all relevant PRs.
> 
> - Update `.buildkite/scripts/cherry-pick-from-milestone.sh` to pass `--limit 1000` to `gh pr list`, avoiding default result truncation
> - Keeps sorting and JSON/JQ processing unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f250188f043b2d6bc2319cbfe1b17cf3d971ba57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
