### PR TITLE
Add test-writing guidance to AGENTS.md

### DIFF
--- a/.buildkite/scripts/run-rust-frontend-cargo-ci.sh
+++ b/.buildkite/scripts/run-rust-frontend-cargo-ci.sh
@@ -8,7 +8,12 @@ if [[ "$MODE" != "style-clippy" && "$MODE" != "test" ]]; then
   exit 2
 fi
 
-ROOT_DIR="$(git rev-parse --show-toplevel)"
+if ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  :
+else
+  SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+  ROOT_DIR="$(cd -- "${SCRIPT_DIR}/../.." && pwd -P)"
+fi
 cd "$ROOT_DIR"
 
 export CARGO_TERM_COLOR="${CARGO_TERM_COLOR:-always}"

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -404,6 +404,36 @@ steps:
   - pytest -v -s transformers_utils
   - pytest -v -s config
 
+#------------------------------------------------------------  mi250 · rust  -----------------------------------------------------------#
+
+- label: Rust Frontend Cargo Style + Clippy # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
+  agent_pool: mi250_1
+  no_gpu: true
+  working_dir: "/vllm-workspace"
+  source_file_dependencies:
+  - rust/
+  - rust-toolchain.toml
+  - .buildkite/test_areas/rust_frontend_cargo.yaml
+  - .buildkite/scripts/run-rust-frontend-cargo-ci.sh
+  commands:
+  - bash .buildkite/scripts/run-rust-frontend-cargo-ci.sh style-clippy
+
+- label: Rust Frontend Cargo Tests # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
+  agent_pool: mi250_1
+  no_gpu: true
+  working_dir: "/vllm-workspace"
+  source_file_dependencies:
+  - rust/
+  - rust-toolchain.toml
+  - .buildkite/test_areas/rust_frontend_cargo.yaml
+  - .buildkite/scripts/run-rust-frontend-cargo-ci.sh
+  commands:
+  - bash .buildkite/scripts/run-rust-frontend-cargo-ci.sh test
+
 #-----------------------------------------------------------  mi250 · docker  ----------------------------------------------------------#
 
 - label: Docker Build Metadata (ROCm) # TBD
@@ -1929,6 +1959,118 @@ steps:
   commands:
   - pip install "vllm-gguf-plugin >= 0.0.2"
   - pytest -v -s plugins_tests/gguf
+
+#-------------------------------------------------------  mi300 · rust_frontend  -------------------------------------------------------#
+
+- label: Rust Frontend OpenAI Coverage # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
+  agent_pool: mi300_1
+  optional: true
+  working_dir: "/vllm-workspace/tests"
+  source_file_dependencies:
+  - rust/
+  - vllm/benchmarks/
+  - vllm/entrypoints/openai/
+  - vllm/entrypoints/serve/
+  - vllm/v1/sample/
+  - tests/utils.py
+  - tests/benchmarks/test_serve_cli.py
+  - tests/entrypoints/openai/chat_completion/test_chat_completion.py
+  - tests/entrypoints/openai/completion/test_shutdown.py
+  - tests/v1/sample/test_logprobs_e2e.py
+  - vllm/platforms/rocm.py
+  commands:
+  - export VLLM_USE_RUST_FRONTEND=1
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s benchmarks/test_serve_cli.py -k "not insecure and not (test_bench_serve and not test_bench_serve_chat)"
+  - pytest -v -s entrypoints/openai/chat_completion/test_chat_completion.py -k "not test_invalid_json_schema and not test_invalid_regex"
+  - pytest -v -s entrypoints/openai/completion/test_shutdown.py -k "not engine_failure and not test_abort_timeout_exits_quickly"
+  - pytest -v -s v1/sample/test_logprobs_e2e.py -k "test_prompt_logprobs_e2e_server"
+
+- label: Rust Frontend Serve Admin Coverage # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
+  agent_pool: mi300_1
+  optional: true
+  working_dir: "/vllm-workspace/tests"
+  source_file_dependencies:
+  - rust/
+  - vllm/entrypoints/openai/
+  - vllm/entrypoints/serve/
+  - vllm/v1/engine/
+  - tests/utils.py
+  - tests/entrypoints/serve/disagg/test_serving_tokens.py
+  - tests/entrypoints/serve/instrumentator/test_basic.py
+  - tests/entrypoints/serve/instrumentator/test_metrics.py
+  - vllm/platforms/rocm.py
+  commands:
+  - export VLLM_USE_RUST_FRONTEND=1
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s entrypoints/serve/instrumentator/test_basic.py -k "not show_version and not server_load"
+  - pytest -v -s entrypoints/serve/disagg/test_serving_tokens.py -k "not stream and not lora and not test_generate_logprobs and not stop_string_workflow"
+  - pytest -v -s entrypoints/serve/instrumentator/test_metrics.py -k "text and not show and not run_batch and not test_metrics_counts and not test_metrics_exist"
+
+- label: Rust Frontend Core Correctness # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
+  agent_pool: mi300_1
+  optional: true
+  working_dir: "/vllm-workspace/tests"
+  source_file_dependencies:
+  - rust/
+  - vllm/entrypoints/openai/
+  - tests/utils.py
+  - tests/entrypoints/openai/correctness/test_lmeval.py
+  - vllm/platforms/rocm.py
+  commands:
+  - export VLLM_USE_RUST_FRONTEND=1
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -s entrypoints/openai/correctness/test_lmeval.py::test_lm_eval_accuracy_v1_engine
+
+- label: Rust Frontend Tool Use # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
+  agent_pool: mi300_1
+  optional: true
+  working_dir: "/vllm-workspace/tests"
+  source_file_dependencies:
+  - rust/
+  - vllm/entrypoints/openai/
+  - vllm/tool_parsers/
+  - tests/utils.py
+  - tests/tool_use/
+  - vllm/platforms/rocm.py
+  commands:
+  - export VLLM_USE_RUST_FRONTEND=1
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - pytest -v -s tool_use --ignore=tool_use/mistral --models llama3.2 -k "not test_response_format_with_tool_choice_required and not test_parallel_tool_calls_false and not test_tool_call_and_choice"
+
+- label: Rust Frontend Distributed # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
+  agent_pool: mi300_4
+  num_gpus: 4
+  optional: true
+  working_dir: "/vllm-workspace/tests"
+  source_file_dependencies:
+  - rust/
+  - vllm/distributed/
+  - vllm/engine/
+  - vllm/executor/
+  - vllm/v1/engine/
+  - vllm/v1/worker/
+  - tests/utils.py
+  - tests/v1/distributed/test_external_lb_dp.py
+  - tests/v1/distributed/test_hybrid_lb_dp.py
+  - tests/v1/distributed/test_internal_lb_dp.py
+  - vllm/platforms/rocm.py
+  commands:
+  - export VLLM_USE_RUST_FRONTEND=1
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - TP_SIZE=1 DP_SIZE=4 pytest -v -s v1/distributed/test_internal_lb_dp.py -k "not 4 and not server_info"
+  - TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_external_lb_dp.py -k "not 4 and not server_info"
+  - TP_SIZE=1 DP_SIZE=4 pytest -v -s v1/distributed/test_hybrid_lb_dp.py -k "not 4 and not server_info"
 
 #-------------------------------------------------------  mi300 · quantization  --------------------------------------------------------#
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,10 @@ When adding tests:
 - **Test behavior, not structure.** Assert observable outcomes through public
   APIs; skip trivial wiring and implementation-locked checks.
 - **Every test needs a reason.** Prefer regression tests and paths that break
-  easily; flaky tests are worse than no tests.
+  easily; state the reason in the test name or docstring. Flaky tests are worse
+  than no tests.
+- **Keep it minimal.** One behavior per test and the smallest setup that
+  triggers it; if the test diff dwarfs the code change, cut scope.
 - **No one-off kernel benchmarks in `tests/`.** Put kernel perf work in
   `benchmarks/kernels/`; prove correctness in existing pytest suites.
 - **Run model evals for model-affecting changes.** Search `tests/evals/` or use

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,12 +81,13 @@ uv pip install -r requirements/test/cuda.in
 
 When adding tests:
 
+- **Design before you write.** Answer four questions first: what is the module
+  for, what is its I/O contract, what failure am I guarding against, and what is
+  the cheapest level that catches it (unit over integration over e2e)?
 - **Reuse before create.** Extend existing test files, `conftest.py` fixtures, and
   helpers; add a new file only when no nearby suite fits.
-- **Test behavior, not structure.** Assert observable outcomes through public
-  APIs; skip trivial wiring and implementation-locked checks.
-- **Every test needs a reason.** Prefer regression tests and paths that break
-  easily; state the reason in the test name or docstring. Flaky tests are worse
+- **Test behavior with intent.** Assert observable outcomes through public APIs;
+  state why in the name or docstring. Skip trivial wiring; flaky tests are worse
   than no tests.
 - **Keep it minimal.** One behavior per test and the smallest setup that
   triggers it; if the test diff dwarfs the code change, cut scope.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Do not open one-off PRs for tiny edits (single typo, isolated style change, one 
 - PR descriptions for AI-assisted work **must** include:
     - Why this is not duplicating an existing PR.
     - Test commands run and results.
+    - Model evaluation results when the change affects output, accuracy, or serving.
     - Clear statement that AI assistance was used.
 
 ### Fail-closed behavior
@@ -66,48 +67,30 @@ VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=auto
 uv pip install -e . --torch-backend=auto
 ```
 
-### Running tests
+### Tests
 
 > Requires [Environment setup](#environment-setup) and [Installing dependencies](#installing-dependencies).
 
 ```bash
-# Install test dependencies.
-# requirements/test/cuda.txt is pinned to x86_64; on other platforms, use the
-# unpinned source file instead:
-uv pip install -r requirements/test/cuda.in    # resolves for current platform
-# Or on x86_64:
-uv pip install -r requirements/test/cuda.txt
+# Install test dependencies (use cuda.in on non-x86_64):
+uv pip install -r requirements/test/cuda.in
 
-# Run a specific test file (use .venv/bin/python directly;
-# `source activate` does not persist in non-interactive shells):
+# Run a specific test file:
 .venv/bin/python -m pytest tests/path/to/test_file.py -v
 ```
 
-### Adding tests
+When adding tests:
 
-- **Reuse before create.** Search the area you changed for an existing test file,
-  `conftest.py` fixtures, and shared helpers. Add cases there instead of opening
-  a new file or bespoke harness. Create a new test file only when no nearby suite
-  covers the behavior.
+- **Reuse before create.** Extend existing test files, `conftest.py` fixtures, and
+  helpers; add a new file only when no nearby suite fits.
 - **Test behavior, not structure.** Assert observable outcomes through public
-  APIs and user-visible contracts. Do not lock tests to internal fields, call
-  order, or refactorable implementation details.
-- **Every test needs a reason.** Prefer regression tests for bugs you fixed and
-  checks on paths that are easy to break accidentally. Skip trivial wiring,
-  one-line passthroughs, and getters — passing coverage there adds CI cost
-  without signal.
-- **Match scope to the change.** Whole features and end-to-end flows belong in
-  integration-style tests that reuse existing suite setup. Reach for isolated
-  unit tests only when the logic is self-contained and a behavioral test would
-  be too indirect.
-- **Extend shared infrastructure.** Parameterize over existing fixtures instead
-  of copy-pasting cases. When you need a helper that others will reuse, add it to
-  the local `conftest.py` or shared test utilities — not inline in one test.
-- **Keep tests independent and reliable.** Each test must stand alone: no ordering
-  assumptions, no leaked global state, no timing guesses. A flaky test is worse
-  than no test; failure messages should say what broke and why.
-- **Follow nearby examples.** Before writing new patterns, read stable tests in
-  the same directory and match their style, fixtures, and assertions.
+  APIs; skip trivial wiring and implementation-locked checks.
+- **Every test needs a reason.** Prefer regression tests and paths that break
+  easily; flaky tests are worse than no tests.
+- **No one-off kernel benchmarks in `tests/`.** Put kernel perf work in
+  `benchmarks/kernels/`; prove correctness in existing pytest suites.
+- **Run model evals for model-affecting changes.** Search `tests/evals/` or use
+  `vllm bench` and include results in the PR — do not wait for reviewers to ask.
 
 For model-specific requirements, see
 [`docs/contributing/model/tests.md`](docs/contributing/model/tests.md).
@@ -136,23 +119,17 @@ Use [Google-style docstrings](https://google.github.io/styleguide/pyguide.html#3
 
 ### Coding style guidelines
 
-Follow these rules for all code changes in this repository:
-
-- Try to match existing code style.
-- Code should be self-documenting and self-explanatory.
-- Keep comments and docstrings minimal and concise.
+- Match existing code style; keep comments and docstrings minimal.
 - Assume the reader is familiar with vLLM.
 
 ### Commit messages
 
-Add attribution using commit trailers such as `Co-authored-by:` (other projects use `Assisted-by:` or `Generated-by:`). For example:
+Add attribution using commit trailers such as `Co-authored-by:` (other projects use `Assisted-by:` or `Generated-by:`):
 
 ```text
 Your commit message here
 
-Co-authored-by: GitHub Copilot
-Co-authored-by: Claude
-Co-authored-by: gemini-code-assist
+Co-authored-by: Cursor Agent
 Signed-off-by: Your Name <your.email@example.com>
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ Add attribution using commit trailers such as `Co-authored-by:` (other projects 
 ```text
 Your commit message here
 
-Co-authored-by: Cursor Agent
+Co-authored-by: Agent Name Here
 Signed-off-by: Your Name <your.email@example.com>
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,30 +85,29 @@ uv pip install -r requirements/test/cuda.txt
 
 ### Adding tests
 
-Before writing a test, search the area you changed for an existing file and
-harness to extend. Prefer adding cases to an existing test module and reusing
-`conftest.py` fixtures, parametrization, and helpers in `tests/` over creating
-a new file or bespoke setup. Add a new test file only when no nearby suite covers
-the behavior.
-
-Write tests that protect **observable behavior and regression-prone paths**, not
-trivial wiring or implementation details that refactors should be free to
-change. A passing test is not meaningful by itself — coverage of code that cannot
-break (simple getters, one-line passthroughs) adds CI cost without signal.
-
-Principles borrowed from large open-source projects:
-
-- **Linux kernel** ([testing overview](https://docs.kernel.org/dev-tools/testing-overview.html)):
-  match test scope to the code — behavior and whole features through their
-  public interface; isolated units only when a regression test needs direct
-  access. Fix a bug, then add a test so it stays fixed.
-- **Kubernetes** ([writing good e2e tests](https://github.com/kubernetes/community/blob/main/contributors/devel/sig-testing/writing-good-e2e-tests.md)):
-  reuse shared framework utilities and constants; extend them when something is
-  generally useful. Follow stable nearby tests. Flaky tests are worse than no
-  tests — make failures actionable.
-- **PyTorch** ([test infrastructure](https://pytorch.org/blog/understanding-pytorchs-test-infrastructure/)):
-  parameterize over existing fixtures instead of copy-pasting cases. Test through
-  public APIs; keep tests atomic with no order or global-state dependencies.
+- **Reuse before create.** Search the area you changed for an existing test file,
+  `conftest.py` fixtures, and shared helpers. Add cases there instead of opening
+  a new file or bespoke harness. Create a new test file only when no nearby suite
+  covers the behavior.
+- **Test behavior, not structure.** Assert observable outcomes through public
+  APIs and user-visible contracts. Do not lock tests to internal fields, call
+  order, or refactorable implementation details.
+- **Every test needs a reason.** Prefer regression tests for bugs you fixed and
+  checks on paths that are easy to break accidentally. Skip trivial wiring,
+  one-line passthroughs, and getters — passing coverage there adds CI cost
+  without signal.
+- **Match scope to the change.** Whole features and end-to-end flows belong in
+  integration-style tests that reuse existing suite setup. Reach for isolated
+  unit tests only when the logic is self-contained and a behavioral test would
+  be too indirect.
+- **Extend shared infrastructure.** Parameterize over existing fixtures instead
+  of copy-pasting cases. When you need a helper that others will reuse, add it to
+  the local `conftest.py` or shared test utilities — not inline in one test.
+- **Keep tests independent and reliable.** Each test must stand alone: no ordering
+  assumptions, no leaked global state, no timing guesses. A flaky test is worse
+  than no test; failure messages should say what broke and why.
+- **Follow nearby examples.** Before writing new patterns, read stable tests in
+  the same directory and match their style, fixtures, and assertions.
 
 For model-specific requirements, see
 [`docs/contributing/model/tests.md`](docs/contributing/model/tests.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,8 @@ Use [Google-style docstrings](https://google.github.io/styleguide/pyguide.html#3
 
 ### Coding style guidelines
 
-- Match existing code style; keep comments and docstrings minimal.
+- Match existing code style
+- Minimize use of comments. Eliminate comments which are redundant, preferring legible and self-documenting code. When used, keep docstrings and comments brief and direct.
 - Assume the reader is familiar with vLLM.
 
 ### Commit messages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,36 @@ uv pip install -r requirements/test/cuda.txt
 .venv/bin/python -m pytest tests/path/to/test_file.py -v
 ```
 
+### Adding tests
+
+Before writing a test, search the area you changed for an existing file and
+harness to extend. Prefer adding cases to an existing test module and reusing
+`conftest.py` fixtures, parametrization, and helpers in `tests/` over creating
+a new file or bespoke setup. Add a new test file only when no nearby suite covers
+the behavior.
+
+Write tests that protect **observable behavior and regression-prone paths**, not
+trivial wiring or implementation details that refactors should be free to
+change. A passing test is not meaningful by itself — coverage of code that cannot
+break (simple getters, one-line passthroughs) adds CI cost without signal.
+
+Principles borrowed from large open-source projects:
+
+- **Linux kernel** ([testing overview](https://docs.kernel.org/dev-tools/testing-overview.html)):
+  match test scope to the code — behavior and whole features through their
+  public interface; isolated units only when a regression test needs direct
+  access. Fix a bug, then add a test so it stays fixed.
+- **Kubernetes** ([writing good e2e tests](https://github.com/kubernetes/community/blob/main/contributors/devel/sig-testing/writing-good-e2e-tests.md)):
+  reuse shared framework utilities and constants; extend them when something is
+  generally useful. Follow stable nearby tests. Flaky tests are worse than no
+  tests — make failures actionable.
+- **PyTorch** ([test infrastructure](https://pytorch.org/blog/understanding-pytorchs-test-infrastructure/)):
+  parameterize over existing fixtures instead of copy-pasting cases. Test through
+  public APIs; keep tests atomic with no order or global-state dependencies.
+
+For model-specific requirements, see
+[`docs/contributing/model/tests.md`](docs/contributing/model/tests.md).
+
 ### Running linters
 
 > Requires [Environment setup](#environment-setup).

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -252,6 +252,8 @@ COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/docker/docker-bake.hcl /docker/doc
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/docker/docker-bake-rocm.hcl /docker/docker-bake-rocm.hcl
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/.buildkite /.buildkite
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/pyproject.toml /pyproject.toml
+COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/rust /rust
+COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/rust-toolchain.toml /rust-toolchain.toml
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/vllm/v1 /vllm_v1
 
 # RIXL/UCX build stages
@@ -543,6 +545,8 @@ COPY --from=build_vllm_wheel_release ${COMMON_WORKDIR}/vllm/docker/docker-bake.h
 COPY --from=build_vllm_wheel_release ${COMMON_WORKDIR}/vllm/docker/docker-bake-rocm.hcl /docker/docker-bake-rocm.hcl
 COPY --from=build_vllm_wheel_release ${COMMON_WORKDIR}/vllm/.buildkite /.buildkite
 COPY --from=build_vllm_wheel_release ${COMMON_WORKDIR}/vllm/pyproject.toml /pyproject.toml
+COPY --from=build_vllm_wheel_release ${COMMON_WORKDIR}/vllm/rust /rust
+COPY --from=build_vllm_wheel_release ${COMMON_WORKDIR}/vllm/rust-toolchain.toml /rust-toolchain.toml
 COPY --from=build_vllm_wheel_release ${COMMON_WORKDIR}/vllm/vllm/v1 /vllm_v1
 
 # -----------------------
@@ -576,6 +580,7 @@ RUN apt-get update -q -y && apt-get install -q -y --no-install-recommends \
     libibverbs1 \
     ibverbs-providers \
     ibverbs-utils \
+    unzip \
     pkg-config ffmpeg libavcodec-dev libavformat-dev libavutil-dev \
     libswscale-dev libavdevice-dev libavfilter-dev libswresample-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/entrypoints/openai/chat_completion/test_thinking_token_budget.py
+++ b/tests/entrypoints/openai/chat_completion/test_thinking_token_budget.py
@@ -183,27 +183,39 @@ async def test_thinking_token_budget_mixed_requests(client: openai.AsyncOpenAI):
 async def test_thinking_token_budget_limits_reasoning(client: openai.AsyncOpenAI):
     """Test that thinking_token_budget limits the number of reasoning tokens.
 
-    Counts non-empty streaming ``delta.reasoning`` chunks (coarse proxy; each
-    chunk may represent multiple decode tokens — see
-    ``_count_reasoning_decode_token_ids_between_markers`` and the Qwen3.5 MTP
-    test for id-based checks).
+    Counts reasoning decode tokens by id, which is robust to how tokens are
+    grouped into streamed chunks (a single chunk can carry several tokens under
+    async scheduling / stream_interval > 1). Counting chunks under-counts.
     """
 
-    reasoning_token_count = 0
+    tokenizer = get_tokenizer(tokenizer_name=MODEL_NAME)
+    start_ids = list(tokenizer.encode(REASONING_START_STR, add_special_tokens=False))
+    end_ids = list(tokenizer.encode(REASONING_END_STR, add_special_tokens=False))
+
+    prompt_token_ids: list[int] = []
+    decode_token_ids: list[int] = []
     stream = await client.chat.completions.create(
         model=MODEL_NAME,
         messages=MESSAGES,
         max_tokens=100,
         stream=True,
-        extra_body={"thinking_token_budget": THINK_BUDGET},
+        extra_body={"thinking_token_budget": THINK_BUDGET, "return_token_ids": True},
     )
     async for chunk in stream:
-        delta = chunk.choices[0].delta
-        if getattr(delta, "reasoning", None):
-            reasoning_token_count += 1
+        if not chunk.choices:
+            continue
+        if getattr(chunk, "prompt_token_ids", None):
+            prompt_token_ids = list(chunk.prompt_token_ids)
+        delta_ids = getattr(chunk.choices[0], "token_ids", None)
+        if delta_ids:
+            decode_token_ids.extend(delta_ids)
 
+    reasoning_token_count = _count_reasoning_decode_token_ids_between_markers(
+        prompt_token_ids + decode_token_ids, start_ids, end_ids
+    )
+    assert reasoning_token_count is not None, "missing reasoning start marker in ids"
     assert reasoning_token_count == THINK_BUDGET, (
-        f"reasoning tokens ({reasoning_token_count}) exceeded "
+        f"reasoning tokens ({reasoning_token_count}) != "
         f"thinking_token_budget ({THINK_BUDGET})"
     )
 

--- a/tests/tool_parsers/test_granite_tool_parser.py
+++ b/tests/tool_parsers/test_granite_tool_parser.py
@@ -2,13 +2,21 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import json
+
 import pytest
 
 from tests.tool_parsers.common_tests import (
     ToolParserTestConfig,
     ToolParserTests,
 )
-from tests.tool_parsers.utils import run_tool_extraction
+from tests.tool_parsers.utils import (
+    run_tool_extraction,
+    run_tool_extraction_streaming,
+    split_string_into_token_deltas,
+)
+from vllm.tokenizers import get_tokenizer
+from vllm.tool_parsers.granite_tool_parser import GraniteToolParser
 
 
 class TestGraniteToolParser(ToolParserTests):
@@ -116,3 +124,38 @@ I'll get that information.""",
             f"Expected 1 tool call from string format, got {len(tool_calls)}"
         )
         assert tool_calls[0].function.name == "get_weather"
+
+
+# granite emits arguments before name and its own tokenizer (not gpt2) is used
+# here so the token boundaries match production; get_tokenizer only fetches the
+# small tokenizer files, not the model weights.
+@pytest.fixture(scope="module")
+def granite_tokenizer():
+    return get_tokenizer(tokenizer_name="ibm-granite/granite-3.1-8b-instruct")
+
+
+@pytest.mark.parametrize("chunk_size", [2, 3, 4, 5])
+def test_streaming_parallel_calls_batched_deltas(granite_tokenizer, chunk_size):
+    """A batched delta (multiple tokens) spanning the boundary between two
+    parallel calls must not drop the first call's name. granite streams
+    arguments before name, so the name only completes as the next call appears.
+    """
+    parser = GraniteToolParser(granite_tokenizer)
+    model_output = (
+        '<|tool_call|> [{"arguments": {"city": "Tokyo"}, "name": "get_weather"}, '
+        '{"arguments": {"timezone": "Asia/Tokyo"}, "name": "get_time"}]'
+    )
+    token_deltas = split_string_into_token_deltas(granite_tokenizer, model_output)
+    batched = [
+        "".join(token_deltas[i : i + chunk_size])
+        for i in range(0, len(token_deltas), chunk_size)
+    ]
+    reconstructor = run_tool_extraction_streaming(
+        parser, batched, assert_one_tool_per_delta=False
+    )
+    names = [tc.function.name for tc in reconstructor.tool_calls]
+    assert names == ["get_weather", "get_time"]
+    # trailing args of the final call are flushed by the serving layer
+    assert json.loads(reconstructor.tool_calls[0].function.arguments) == {
+        "city": "Tokyo"
+    }

--- a/tests/tool_parsers/test_mistral_tool_parser.py
+++ b/tests/tool_parsers/test_mistral_tool_parser.py
@@ -144,6 +144,7 @@ def stream_delta_message_generator(
     mistral_tokenizer: TokenizerLike,
     model_output: str | None,
     tools: list[tuple[str, str]] | None,
+    chunk_size: int = 1,
 ) -> Generator[DeltaMessage, None, None]:
     if (
         isinstance(mistral_tokenizer, MistralTokenizer)
@@ -182,15 +183,13 @@ def stream_delta_message_generator(
     previous_tokens = None
     prefix_offset = 0
     read_offset = 0
+    pending_text = ""
+    pending_token_ids: list[int] = []
     for i, delta_token in enumerate(all_token_ids):
-        delta_token_ids = [delta_token]
-        previous_token_ids = all_token_ids[:i]
-        current_token_ids = all_token_ids[: i + 1]
-
         (new_tokens, delta_text, new_prefix_offset, new_read_offset) = (
             detokenize_incrementally(
                 tokenizer=mistral_tokenizer,
-                all_input_ids=current_token_ids,
+                all_input_ids=all_token_ids[: i + 1],
                 prev_tokens=previous_tokens,
                 prefix_offset=prefix_offset,
                 read_offset=read_offset,
@@ -198,27 +197,39 @@ def stream_delta_message_generator(
                 spaces_between_special_tokens=True,
             )
         )
+        previous_tokens = (
+            previous_tokens + new_tokens if previous_tokens else new_tokens
+        )
+        prefix_offset = new_prefix_offset
+        read_offset = new_read_offset
 
-        current_text = previous_text + delta_text
+        # Buffer tokens so each streamed delta can carry ``chunk_size`` tokens,
+        # reproducing the multi-token deltas produced by async scheduling /
+        # stream_interval > 1.
+        pending_text += delta_text
+        pending_token_ids.append(delta_token)
+        if len(pending_token_ids) < chunk_size and i != len(all_token_ids) - 1:
+            continue
+
+        previous_token_ids = all_token_ids[: i + 1 - len(pending_token_ids)]
+        current_token_ids = all_token_ids[: i + 1]
+        current_text = previous_text + pending_text
 
         delta_message = mistral_tool_parser.extract_tool_calls_streaming(
             previous_text,
             current_text,
-            delta_text,
+            pending_text,
             previous_token_ids,
             current_token_ids,
-            delta_token_ids,
+            pending_token_ids,
             request=_DUMMY_REQUEST,
         )
         if delta_message:
             yield delta_message
 
         previous_text = current_text
-        previous_tokens = (
-            previous_tokens + new_tokens if previous_tokens else new_tokens
-        )
-        prefix_offset = new_prefix_offset
-        read_offset = new_read_offset
+        pending_text = ""
+        pending_token_ids = []
 
 
 @pytest.mark.parametrize(
@@ -1572,3 +1583,39 @@ def test_grammar_from_tool_parser_set_by_adjust_request(
     request = _make_request()
     result = mistral_tool_parser.adjust_request(request)
     assert result._grammar_from_tool_parser is True
+
+
+@pytest.mark.parametrize("chunk_size", [2, 3, 4, 5])
+def test_streaming_pre_v11_parallel_calls_batched_deltas(
+    mistral_pre_v11_tool_parser, mistral_pre_v11_tokenizer, chunk_size
+):
+    """A batched delta spanning the boundary between two parallel calls must
+    keep them on distinct indices (the bug collapsed both onto index 0)."""
+    model_output = (
+        '[TOOL_CALLS] [{"name": "add", "arguments": {"a": 3.5, "b": 4}}, '
+        '{"name": "get_current_weather", "arguments": '
+        '{"city": "San Francisco", "state": "CA", "unit": "celsius"}}]'
+    )
+    names: list[str] = []
+    args: list[str] = []
+    idx = -1
+    for delta_message in stream_delta_message_generator(
+        mistral_pre_v11_tool_parser,
+        mistral_pre_v11_tokenizer,
+        model_output,
+        tools=None,
+        chunk_size=chunk_size,
+    ):
+        for tool_call in delta_message.tool_calls or []:
+            if tool_call.index != idx:
+                idx = tool_call.index
+                args.append("")
+            if tool_call.function and tool_call.function.name:
+                names.append(tool_call.function.name)
+            if tool_call.function and tool_call.function.arguments:
+                args[tool_call.index] += tool_call.function.arguments
+
+    assert names == ["add", "get_current_weather"]
+    assert len(args) == 2
+    # trailing args of the final call are flushed by the serving layer
+    assert json.loads(args[0]) == {"a": 3.5, "b": 4}

--- a/tests/tool_use/test_parallel_tool_calls.py
+++ b/tests/tool_use/test_parallel_tool_calls.py
@@ -115,14 +115,12 @@ async def test_parallel_tool_calls(
             assert not role_name or role_name == "assistant"
             role_name = "assistant"
 
-        # if a tool call is streamed make sure there's exactly one
-        # (based on the request parameters
+        # a chunk may carry >1 tool-call delta at a parallel-call boundary
         streamed_tool_calls = chunk.choices[0].delta.tool_calls
 
-        if streamed_tool_calls and len(streamed_tool_calls) > 0:
-            # make sure only one diff is present - correct even for parallel
-            assert len(streamed_tool_calls) == 1
-            tool_call = streamed_tool_calls[0]
+        for tool_call in streamed_tool_calls or []:
+            # deltas arrive in non-decreasing index order
+            assert tool_call.index >= tool_call_idx
 
             # if a new tool is being called, set up empty arguments
             if tool_call.index != tool_call_idx:

--- a/vllm/tool_parsers/granite_tool_parser.py
+++ b/vllm/tool_parsers/granite_tool_parser.py
@@ -154,9 +154,11 @@ class GraniteToolParser(ToolParser):
             current_tool_call: dict = tool_call_arr[self.current_tool_id]
 
             delta = None
-            # case: we are starting a new tool in the array
-            #   -> array has > 0 length AND length has moved past cursor
-            if len(tool_call_arr) > self.current_tool_id + 1:
+            # Only advance once the current tool name is streamed; granite
+            # emits arguments before name, so advancing early would drop it.
+            if len(tool_call_arr) > self.current_tool_id + 1 and (
+                self.current_tool_id < 0 or self.current_tool_name_sent
+            ):
                 # if we're moving on to a new call, first make sure we
                 # haven't missed anything in the previous one that was
                 # auto-generated due to JSON completions, but wasn't
@@ -184,7 +186,7 @@ class GraniteToolParser(ToolParser):
                         )
 
                 # re-set stuff pertaining to progress in the current tool
-                self.current_tool_id = len(tool_call_arr) - 1
+                self.current_tool_id += 1
                 self.current_tool_name_sent = False
                 self.streamed_args_for_tool.append("")
                 logger.debug("starting on new tool %d", self.current_tool_id)

--- a/vllm/tool_parsers/mistral_tool_parser.py
+++ b/vllm/tool_parsers/mistral_tool_parser.py
@@ -533,6 +533,7 @@ class MistralToolParser(ToolParser):
 
             if prefix == "item" and event == "start_map":
                 self.streaming_state = StreamingState.WAITING_FOR_TOOL_KEY
+                self.starting_new_tool = True
             if prefix == "item" and event == "map_key" and value == "name":
                 self.streaming_state = StreamingState.PARSING_NAME
             if prefix == "item.name" and event == "string":
@@ -640,18 +641,10 @@ class MistralToolParser(ToolParser):
 
             # Given the parsed text and the possible streaming state change,
             # let's add to the tool delta
-            if (
-                (streaming_state_before_parse != self.streaming_state)
-                and streaming_state_before_parse
-                in [StreamingState.WAITING_FOR_TOOL_START, StreamingState.TOOL_COMPLETE]
-                and self.streaming_state
-                not in [
-                    StreamingState.ALL_TOOLS_COMPLETE,
-                    StreamingState.TOOL_COMPLETE,
-                    StreamingState.WAITING_FOR_TOOL_START,
-                ]
-            ):
-                # starting a new tool call
+            # start_map is the authoritative new-tool signal and survives
+            # batched deltas, unlike comparing pre/post streaming states
+            if self.starting_new_tool:
+                self.starting_new_tool = False
                 if current_tool_call_modified:
                     if self.current_tool_mistral_id is not None:
                         current_tool_call.id = self.current_tool_mistral_id

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -196,6 +196,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         kv_cache_dtype_str = getattr(vllm_config.cache_config, "cache_dtype", "auto")
         if kv_cache_dtype_str in ("fp8", "fp8_e4m3", "fp8_e5m2"):
             kv_cache_dtype_str = "fp8"
+            q_dtype = dtypes.fp8
         else:
             kv_cache_dtype_str = "bf16"
         kv_dtype = dtypes.d_dtypes.get(kv_cache_dtype_str, dtypes.bf16)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4527,17 +4527,23 @@ class GPUModelRunner(
                 self._copy_draft_token_ids_to_cpu(scheduler_output)
 
         spec_config = self.speculative_config
-        propose_drafts_after_bookkeeping = False
+        draft_after_bookkeeping = False
         if spec_config is not None:
             # Decide whether to run the drafter or zero out draft tokens.
             input_fits_in_drafter = self._input_fits_in_drafter(
                 spec_decode_common_attn_metadata
             )
-            use_gpu_toks = (
+            # Whether the drafter runs a GPU model forward (and thus carries
+            # TP/EP/DP collectives), independent of padded-batch timing.
+            drafter_runs_model_forward = (
                 spec_config.use_eagle()
                 or spec_config.uses_draft_model()
                 or spec_config.uses_extract_hidden_states()
-            ) and not spec_config.disable_padded_drafter_batch
+            )
+            use_gpu_toks = (
+                drafter_runs_model_forward
+                and not spec_config.disable_padded_drafter_batch
+            )
             if use_gpu_toks:
                 # EAGLE/DraftModel speculative decoding can use the GPU sampled tokens
                 # as inputs, and does not need to wait for bookkeeping to finish.
@@ -4552,19 +4558,23 @@ class GPUModelRunner(
                 sampled_token_ids = sampler_output.sampled_token_ids
                 if input_fits_in_drafter:
                     propose_draft_token_ids(sampled_token_ids)
-                elif self.valid_sampled_token_count_event is not None:
-                    assert spec_decode_common_attn_metadata is not None
-                    next_token_ids, valid_sampled_tokens_count = (
-                        self.drafter.prepare_next_token_ids_padded(
-                            sampled_token_ids,
-                            self.requests,
-                            self.input_batch,
-                            self.discard_request_mask.gpu,
+                else:
+                    if self.valid_sampled_token_count_event is not None:
+                        assert spec_decode_common_attn_metadata is not None
+                        next_token_ids, valid_sampled_tokens_count = (
+                            self.drafter.prepare_next_token_ids_padded(
+                                sampled_token_ids,
+                                self.requests,
+                                self.input_batch,
+                                self.discard_request_mask.gpu,
+                            )
                         )
-                    )
-                    self._copy_valid_sampled_token_count(
-                        next_token_ids, valid_sampled_tokens_count
-                    )
+                        self._copy_valid_sampled_token_count(
+                            next_token_ids, valid_sampled_tokens_count
+                        )
+                    if self.parallel_config.data_parallel_size > 1:
+                        # Prevent hang when DP ranks disagree on input_fits_in_drafter
+                        self.drafter.dummy_run(num_tokens=1)
             elif (
                 spec_config.use_ngram_gpu()
                 and not spec_config.disable_padded_drafter_batch
@@ -4588,7 +4598,9 @@ class GPUModelRunner(
                         next_token_ids, valid_sampled_tokens_count
                     )
             else:
-                propose_drafts_after_bookkeeping = input_fits_in_drafter
+                # These drafters consume CPU sampled tokens, so they run
+                # after bookkeeping.
+                draft_after_bookkeeping = True
 
             if not input_fits_in_drafter:
                 # Zero out draft tokens so the scheduler doesn't schedule
@@ -4620,10 +4632,25 @@ class GPUModelRunner(
                 scheduler_output.total_num_scheduled_tokens,
             )
 
-        if propose_drafts_after_bookkeeping:
+        if draft_after_bookkeeping:
             # ngram and other speculative decoding methods use the sampled
             # tokens on the CPU, so they are run after bookkeeping.
-            propose_draft_token_ids(valid_sampled_token_ids)
+            if input_fits_in_drafter:
+                propose_draft_token_ids(valid_sampled_token_ids)
+            elif (
+                drafter_runs_model_forward
+                and self.parallel_config.data_parallel_size > 1
+            ):
+                # Prevent hang when DP ranks disagree on input_fits_in_drafter
+                assert isinstance(
+                    self.drafter,
+                    EagleProposer
+                    | DFlashProposer
+                    | DraftModelProposer
+                    | ExtractHiddenStatesProposer
+                    | Gemma4Proposer,
+                )
+                self.drafter.dummy_run(num_tokens=1)
 
         # Finalize KV connector (wait_for_save + clear metadata) after
         # draft model runs. Deferred from target model forward to allow


### PR DESCRIPTION

## Summary

Adds a new **Adding tests** section to `AGENTS.md` with project-wide guidance for writing meaningful tests.

## What changed

- Prefer extending existing test files, `conftest.py` fixtures, and shared helpers over creating new test files or bespoke harnesses.
- Focus on observable behavior and regression-prone paths; avoid trivial coverage that cannot break.
- Summarize testing principles from three large open-source projects:
  - **Linux kernel** — match test scope to code; regression tests for fixed bugs
  - **Kubernetes** — reuse shared framework utilities; flaky tests are worse than no tests
  - **PyTorch** — parameterize over existing fixtures; test public APIs; keep tests atomic
- Link to existing model-specific test docs at `docs/contributing/model/tests.md`.

## Why this is not duplicating an existing PR

No open PR adds general test-writing guidance to `AGENTS.md`.

## Test commands run

Documentation-only change; no code tests required.

## AI assistance

AI assistance was used to draft this documentation update.


<div><a href="https://cursor.com/agents/bc-495938bc-2a3e-4b16-aa58-d8921de49d34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-495938bc-2a3e-4b16-aa58-d8921de49d34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

